### PR TITLE
Use tagged container version 0.2.6.1 with updated lotus node

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,4 +12,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: latest ##0.1.0
+appVersion: 0.2.6.1


### PR DESCRIPTION
- Use the new tagged version of the filecoin-docker container found here: https://hub.docker.com/r/openworklabs/lotus/tags

I ran `make install` after this change and confirmed it spun up with the new version of lotus. 

```
kubectl get pods
NAME               READY   STATUS    RESTARTS   AGE
lotus-node-app-0   1/1     Running   0          12m
lotus-node-app-1   1/1     Running   0          76s
```

```
kubectl exec -it lotus-node-app-0 -- /bin/bash
root@lotus-node-app-0:/# /usr/local/bin/lotus --version
lotus version 0.2.6+git7b258edd
```