### PR TITLE
Switch to upgrade --install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: lint package
 
 install:
-	helm install filecoin .
+	helm upgrade --install filecoin .
 
 uninstall:
 	helm uninstall filecoin


### PR DESCRIPTION
* Switch to using `helm upgrade --install` rather than `helm install` so we can easily upgrade existing clusters

After changing Chart.yaml from `0.2.5.0` to `0.2.6.1` and running the new upgrade command: 
```
kubectl get pods
NAME               READY   STATUS        RESTARTS   AGE
lotus-node-app-0   1/1     Terminating   0          3m27s
lotus-node-app-1   1/1     Running       0          93s
```

`app-1` was a new pod on 0.2.6.1, once it was healthy, it terminated `app-0` and re-rolled `app-0` as a 0.2.6.1 container.

One thing of note, if you run this command multiple times, it keeps bumping the revision even if there is no action to take:
```
make install
helm upgrade --install filecoin .
Release "filecoin" has been upgraded. Happy Helming!
NAME: filecoin
LAST DEPLOYED: Sat Jan 25 18:20:54 2020
NAMESPACE: default
STATUS: deployed
REVISION: 4
```

So if we blindly run this in CI, it'll have crazy high revisions.