### PR TITLE
import lotus chain dump from shared volume and misc

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,7 +8,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-api
+  name: {{ .Release.Name }}-{{ $fullName }}-api
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -33,7 +33,7 @@ spec:
       - path: /
         backend:
           serviceName: lotus-node-service
-          servicePort: {{ .Values.service.port }}  
+          servicePort: {{ .Values.service.port }}
   {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: lotus-node-service
+  name: {{ .Release.Name }}-lotus-node-service
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.service.targetPort }}"
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    app: lotus-node-app
+    name: {{ .Release.Name }}-lotus-node-app
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: lotus-node-app
+  name: {{ .Release.Name }}-lotus-node-app
   labels:
     app: lotus-node-app
 spec:
@@ -26,11 +26,17 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
 {{- end }}
       volumes:
+{{- if .Values.secretVolume.enabled }}
         - name: lotus-secret-vol
           secret:
             secretName: lotus-secret
             defaultMode: 384 # permission 0600
+{{- end }}
+{{- if .Values.init.import.volume }}
+{{ toYaml .Values.init.import.volume | indent 8 }}
+{{- end }}
       initContainers:
+{{- if .Values.secretVolume.enabled }}
       - name: api-keys
         image: busybox
         command: ["/bin/sh","-c"]
@@ -38,20 +44,34 @@ spec:
         volumeMounts:
           - name: lotus-secret-vol
             mountPath: "/secret"
-          - name: lotus-vol
+          - name: {{ .Release.Name }}-lotus-vol
             mountPath: /lotus
+{{- end }}
 {{- if .Values.init.sync.enabled }}
       - name: sync-wait
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         command: ["/bin/entrypoint","-s"]
         volumeMounts:
-          - name: lotus-vol
+          - name: {{ .Release.Name }}-lotus-vol
             mountPath: /root/.lotus
+{{- end }}
+{{- if .Values.init.import.enabled }}
+      - name: import-wait
+        image: debian:stable
+        command: ["/bin/sh","-c"]
+        args: ["until [ -f /chain/chain.car ] && [ ! -f /chain/chain.car.lock ]; do sleep 5; done"]
+        volumeMounts:
+          - name: {{ (index .Values.init.import.volume 0).name }}
+            mountPath: /chain
 {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        {{- if .Values.init.import.enabled }}
+        command: ["/bin/entrypoint","-d", "-i"]
+        {{- else }}
         command: ["/bin/entrypoint","-d"]
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           exec:
@@ -75,14 +95,18 @@ spec:
         - containerPort: 1235
           name: p2p
         volumeMounts:
-          - name: lotus-vol
+          - name: {{ .Release.Name }}-lotus-vol
             mountPath: /root/.lotus
+        {{- if .Values.init.import.enabled }}
+          - name: {{ (index .Values.init.import.volume 0).name }}
+            mountPath: /chain
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: lotus-vol
+        name: {{ .Release.Name }}-lotus-vol
         {{- range $key, $value := .Values.persistence.lotus.annotations }}
             {{ $key }}: {{ $value }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,13 @@ ingress:
 init:
   sync:
     enabled: true
+  import:
+    enabled: true
+    # ideally a shared volume containing chain dump
+    volume: {}
+
+secretVolume:
+  enabled: true
 
 resources: #{}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Chain Import
* add a values stanza for import with options to enable import and specify a volume containing chain dump. Expects volume to contain a valid lotus chain export file named 'chain.car'.
* use a wait container to allow copying chain dumps to attached volume before attempting to start lotus daemon
* check for 'chain.car.lock' file and wait until it's gone. allows operator to create a lock while uploading new chain dump
* use '-i' flag in entrypoint if import enabled

## Misc
* create a means to toggle using lotus-secrets volume in statefulset
* make sure all metadata name fields are unique so multiple helm chart releases can run in same namespace
* update service file to target specific release