### PR TITLE
Update chart to lotus 0.2.10 release for new metrics

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -26,4 +26,4 @@ maintainers: # (optional)
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.7.1
+appVersion: 0.2.10.0

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: lotus-node-service
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.targetPort }}"
+    prometheus.io/path: /debug/metrics
 spec:
   type: {{ .Values.service.type }}
   selector:


### PR DESCRIPTION
This updates the chart to use lotus 0.2.10, which allows us to gather more detailed metrics about the lotus cluster.