### PR TITLE
Add export tools used lotus-shed

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,13 @@ To automate snapshot operations operator can set `persistence.snapshots.automati
 
 In case you want to create the new release based on existing snapshot one can set `persistence.snapshots.automation.restore.enabled` to `true`. In that case Lotus PV will be created based on snapshot named `persistence.snapshots.automation.restore.name`. Note that Snapshot should exist in the very same namespace where the release is deployed.
 
-### Internal snapshots
+### Internal snapshots and IPFS system
 
-One can setup `persistence.snapshots.uploadToIpfs.enabled` to `true` to make an automated cronjob that will take chain snapshots on a daily basis using `lotus chain export` command, and import the exported `.car` file into IPFS system. Note that IPFS must be running for `persistence.snapshots.uploadToIpfs.enabled` to take any effect.
+One can setup `persistence.snapshots.uploadToIpfs.enabled` to `true` to make an automated cronjob that will take chain snapshots on a daily basis and sharing them through IPFS. There are two ways of making snapshots: hot and cold. Hot takes a while but does not require Lotus node to stop. Cold is way more fast, but implies some downwtime.
+
+To setup hot snapshotting system set `persistence.snapshots.uploadToIpfs.export` to `true`. It will use `lotus chain export` command, and import the exported `.car` file into IPFS system. Note that IPFS must be running for snapshotting system to take any effect.
+To setup cold snapshotting system set `persistence.snapshots.uploadToIpfs.export` to `shed`. It will use `lotus-shed export` command. When using cold snapshotting it is important to set both `.Values.persistence.snapshots.uploadToIpfs.shedPeriod` and `.Values.persistence.snapshots.uploadToIpfs.cron` variables. First defines the period of `lotus-shed export` command execution in period format (1s, 1m, 1h, 1d), second defines a snapshot file sharing update period in cron format (X X X X X).
+
 Also `persistence.snapshots.uploadToIpfs.shareToGist` can be configured to automatically refresh the IPFS hash of the exported `.car` at the GitHub Gist. Note that the job will need an access to this Gist. To provide the job with the credentials use secret described in the [persistent secrets](#persistent-secret) section and add `ssh` key to Kubernetes Secret with base64-encoded private key content.
 
 Note: You must use SSH URL in `persistence.snapshots.uploadToIpfs.shareToGist.address` so the `git push` command used inside of the job could use the provided ssh key to access the Gist.

--- a/templates/cron.yaml
+++ b/templates/cron.yaml
@@ -15,6 +15,7 @@ spec:
         spec:
           restartPolicy: "Never"
           serviceAccountName: {{ .Release.Name }}-{{ .Values.serviceAccount.name }}
+{{- if eq .Values.persistence.snapshots.uploadToIpfs.export "true" }}
           initContainers:
           - name: exporter
             image: bitnami/kubectl
@@ -29,6 +30,7 @@ spec:
             - export
             - --recent-stateroots=900 
             - /data/ipfs/lotus-new.car
+{{- end }}
           containers:
           - name: sharer
             image: bitnami/kubectl

--- a/templates/cron.yaml
+++ b/templates/cron.yaml
@@ -42,7 +42,7 @@ spec:
             - --
             - sh
             - -c
-            - mkdir -p /data/ipfs/snapshots && mv /data/ipfs/lotus-new.car /data/ipfs/snapshots/lotus.car && ipfs add /data/ipfs/snapshots/lotus.car > /data/ipfs/snapshots/snapshot.log
+            - if [ -s "/data/ipfs/lotus-new.car" ]; then mkdir -p /data/ipfs/snapshots && mv /data/ipfs/lotus-new.car /data/ipfs/snapshots/lotus.car && ipfs add /data/ipfs/snapshots/lotus.car > /data/ipfs/snapshots/snapshot.log; fi
 {{- if .Values.persistence.snapshots.uploadToIpfs.shareToGist.enabled }}
           - name: gitter
             image: bitnami/kubectl

--- a/templates/cron.yaml
+++ b/templates/cron.yaml
@@ -42,7 +42,7 @@ spec:
             - --
             - sh
             - -c
-            - if [ -s "/data/ipfs/lotus-new.car" ]; then mkdir -p /data/ipfs/snapshots && mv /data/ipfs/lotus-new.car /data/ipfs/snapshots/lotus.car && ipfs add /data/ipfs/snapshots/lotus.car > /data/ipfs/snapshots/snapshot.log; fi
+            - while true; do if ! [[ `pgrep -x "lotus-shed"` ]] && [ -s "/data/ipfs/lotus-new.car" ]; then mkdir -p /data/ipfs/snapshots && mv /data/ipfs/lotus-new.car /data/ipfs/snapshots/lotus.car && ipfs add /data/ipfs/snapshots/lotus.car > /data/ipfs/snapshots/snapshot.log && break; else sleep 60s; fi; done
 {{- if .Values.persistence.snapshots.uploadToIpfs.shareToGist.enabled }}
           - name: gitter
             image: bitnami/kubectl

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -159,14 +159,22 @@ spec:
         image: {{ .Values.image.repository }}
         command: ["/bin/entrypoint","-d"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.IPFS.enabled }}
         env:
+{{- if .Values.IPFS.enabled }}
         - name: LOTUS_CLIENT_USEIPFS
           value: "true"
         - name: LOTUS_CLIENT_IPFSUSEFORRETRIEVAL
           value: "true"
         - name: LOTUS_CLIENT_IPFSMADDR
           value: "/dns4/127.0.0.1/tcp/5001"
+{{- end }}
+{{- if and .Values.IPFS.enabled (eq .Values.persistence.snapshots.uploadToIpfs.export "shed") }}
+        - name: SHEDEXPORT
+          value: "true"
+        - name: SHEDEXPORTPATH
+          value: "/data/ipfs/lotus-new.car"
+        - name: SHEDEXPORTPERIOD
+          value: "{{ .Values.persistence.snapshots.uploadToIpfs.shedPeriod }}" 
 {{- end }}
         livenessProbe:
           httpGet:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -180,7 +180,11 @@ spec:
           httpGet:
             path: /debug/metrics
             port: api
-          initialDelaySeconds: 150
+{{- if and .Values.IPFS.enabled (eq .Values.persistence.snapshots.uploadToIpfs.export "shed") }}
+          initialDelaySeconds: 1200
+{{- else }}
+          initialDelaySeconds: 200
+{{- end }}
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 6

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -176,18 +176,16 @@ spec:
         - name: SHEDEXPORTPERIOD
           value: "{{ .Values.persistence.snapshots.uploadToIpfs.shedPeriod }}" 
 {{- end }}
+{{- if ne .Values.persistence.snapshots.uploadToIpfs.export "shed" }}
         livenessProbe:
           httpGet:
             path: /debug/metrics
             port: api
-{{- if and .Values.IPFS.enabled (eq .Values.persistence.snapshots.uploadToIpfs.export "shed") }}
-          initialDelaySeconds: 1200
-{{- else }}
           initialDelaySeconds: 200
-{{- end }}
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 6
+{{- end }}
         readinessProbe:
           httpGet:
             path: /debug/metrics

--- a/values-nerpanet.yaml
+++ b/values-nerpanet.yaml
@@ -114,6 +114,8 @@ persistence:
       enabled: false
       shareToGist:
         enabled: false
+        # shedPeriod: 6h
+        export: true
         cron: "0 0 * * *"
         #address: https://gist.github.com/openworklabbot/d03393d1f6e70e089e9e8d18922474f6
         #authorEmail: 

--- a/values-spacerace.yaml
+++ b/values-spacerace.yaml
@@ -111,6 +111,8 @@ persistence:
 # If uploadToIpfs is set to true the internal Lotus snapshot will be created and uploaded to the IPFS system. Note that IPFS must be nenabled in that case
     uploadToIpfs:
       enabled: false
+      export: true
+      # shedPeriod: 6h
       shareToGist:
         enabled: false
         cron: "0 0 * * *"

--- a/values/prod/spacerace/space00.yaml
+++ b/values/prod/spacerace/space00.yaml
@@ -13,6 +13,8 @@ persistence:
     uploadToIpfs:
       cron: "0 */6 * * *" 
       enabled: true
+      export: shed
+      shedPeriod: 6h
       shareToGist: 
         enabled: true
         address: git@gist.github.com:d03393d1f6e70e089e9e8d18922474f6.git


### PR DESCRIPTION
Reference: https://github.com/openworklabs/filecoin-docker/pull/23

openworklabs/filecoin-docker/pull/23 introduces a new efficient chain snapshots. This PR enables `lotus-shed` chain snapshots on Kubernetes cluster via request. It is important to understand that `lotus-shed` exports implies node downtime and should not be used in publicly available nodes.